### PR TITLE
Simplified structured logging in json

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const { performance } = require("perf_hooks");
 const chalk = require("chalk");
-const { log } = require("./logger/log");
+const { logger } = require("./logger/log");
 
 const apiLogger = (req, res, next) => {
   const startTime = performance.now();
@@ -17,13 +17,9 @@ const apiLogger = (req, res, next) => {
       apiLatency: latency,
       time: new Date().toISOString(),
       reqBody: req.body,
-      env: process.env.NODE_ENV,
-      msg: "api_stats",
+      env: process.env.NODE_ENV
     };
-    console.log(
-      `[${chalk.bgWhiteBright(chalk.black("API STATS"))}]`,
-      chalk.blue.bold(JSON.stringify(logData))
-    );
+    logger.info("api_stats", logData)
   });
 
   next();
@@ -38,9 +34,9 @@ const processRequestId = (req) => {
   if (!req.headers["X-request-id"]) {
     const requestId = require("crypto").randomBytes(16).toString("hex");
     req.headers['X-request-id'] = requestId;
-    log.defaultMeta["requestId"] = requestId;
+    logger.defaultMeta["requestId"] = requestId;
     return requestId;
   } else if (req.headers["X-request-id"]) {
-    log.defaultMeta["requestId"] = req.headers["X-request-id"];
+    logger.defaultMeta["requestId"] = req.headers["X-request-id"];
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { apiLogger } = require('./app')
-const { log } = require('./logger/log')
+const { logger } = require('./logger/log')
 module.exports = {
   apiLogger,
-  log,
+  logger,
 };

--- a/logger/log.js
+++ b/logger/log.js
@@ -1,21 +1,18 @@
 const winston = require("winston");
 const { colorizeLevel } = require("./helpers/colorizeLevels");
 require("dotenv").config();
+const { combine, timestamp,json } = winston.format
 
-const log = winston.createLogger({
+const logger = winston.createLogger({
   /** initialize requestId */
   defaultMeta: { requestId: "" },
   level: process.env.LOG_LEVEL || 'info',
-  format: winston.format.combine(
+  format: combine(
     colorizeLevel(),
-    winston.format.timestamp(),
-    winston.format.printf(({ level, message, timestamp, requestId }) => {
-      return `[${level}] [${timestamp}] [${requestId}] ${JSON.stringify(
-        message
-      )}`;
-    })
+    timestamp(),
+    json()
   ),
   transports: [new winston.transports.Console()],
 });
 
-module.exports.log = log;
+module.exports.logger = logger;


### PR DESCRIPTION
Changes are done to log data in a json format instead of a string
Renamed the log module to logger ->  as there is an library function "log" provided and could cause confusions.
