### PR TITLE
Configurable Colorize Parameter

### DIFF
--- a/logger/log.js
+++ b/logger/log.js
@@ -12,7 +12,7 @@ const logger = winston.createLogger({
   ),
   transports: [new winston.transports.Console({
     format: combine(
-      colorize({ all: true })
+      colorize({ all: JSON.parse(process.env.COLORIZE_LOG || "false") })
     )
   })],
 });


### PR DESCRIPTION
Previously the colorize option to log was set as default, which is now made configurable my setting COLORIZE_LOG to true/false as required.
Default COLORIZE_LOG is set to false,